### PR TITLE
Fix filter adding more instances

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -72,7 +72,7 @@ class App extends React.Component {
    */
   enterMainWindow(username) {
     if (typeof username === 'string') {
-      this.setState({ username: username });
+      this.setState({ username });
     }
     this.setState({ windowState: 'sessionList' });
   }

--- a/src/components/GameScreen.js
+++ b/src/components/GameScreen.js
@@ -131,4 +131,3 @@ GameScreen.propTypes = {
 /* eslint-enable react/forbid-prop-types */
 
 export default withStyles(styles)(GameScreen);
-

--- a/src/components/IconList.js
+++ b/src/components/IconList.js
@@ -21,7 +21,7 @@ const styles = () => ({
     marginTop: 125,
     width: 200,
     textAlign: 'center',
-    margin: 'auto',
+    margin: 'auto'
   },
   currentItem: {
     width: '100%'

--- a/src/components/Session.js
+++ b/src/components/Session.js
@@ -35,7 +35,7 @@ class Session extends React.Component {
    */
   handleClick() {
     const buttonAmount = parseInt(Number(this.props.sessionObj.buttonAmount), 10);
-    this.props.enterSessionWindow(this.props.sessionObj.name, buttonAmount);
+    this.props.enterSessionWindow(this.props.sessionName, buttonAmount);
     this.props.communication.stopRequestInstances();
   }
 
@@ -43,7 +43,7 @@ class Session extends React.Component {
     const { classes } = this.props;
     return (
       <ListItem divider className={classes.root} button onClick={this.handleClick}>
-        <ListItemText primary={this.props.sessionObj.name} />
+        <ListItemText primary={this.props.sessionName} />
         <ListItemText primary={this.props.sessionObj.gamemode} />
         <ListItemText
           primary={`${this.props.sessionObj.currentlyPlaying}/${this.props.sessionObj.maxPlayers}`}
@@ -62,6 +62,7 @@ Session.propTypes = {
   /* eslint-disable */
   communication: PropTypes.object.isRequired,
   /* eslint-enable */
+  sessionName: PropTypes.string.isRequired,
 };
 /* eslint-enable react/forbid-prop-types */
 

--- a/src/components/SessionList.js
+++ b/src/components/SessionList.js
@@ -23,10 +23,12 @@ class SessionList extends React.Component {
     super(props);
     this.instances = [];
     this.filter = '';
-    this.state = { instances: [] };
+    this.state = { instances: {} };
     this.onInstancesReceived = this.onInstancesReceived.bind(this);
     this.onPlayerAdded = this.onPlayerAdded.bind(this);
+    this.onPlayerRemoved = this.onPlayerRemoved.bind(this);
     this.onInstanceCreated = this.onInstanceCreated.bind(this);
+    this.onInstanceRemoved = this.onInstanceRemoved.bind(this);
     this.filterList = this.filterList.bind(this);
     this.isFiltered = this.isFiltered.bind(this);
     // this.state = { instances: this.props.testSessions};
@@ -44,6 +46,7 @@ class SessionList extends React.Component {
   onInstancesReceived(err, result) {
     if (!err) {
       this.instances = result;
+      console.log(result);
       this.setState({ instances: result });
     } else {
       // TODO: handle error
@@ -55,13 +58,9 @@ class SessionList extends React.Component {
    * player connects.
    */
   onPlayerAdded(playerName, instanceName) {
-    for (let i = 0; i < this.state.instances.length; i += 1) {
-      if (this.state.instances[i].name === instanceName) {
-        const { instances } = this.state;
-        instances[i].currentlyPlaying += 1;
-        this.setState({ instances });
-      }
-    }
+    const { instances } = this.state;
+    instances[instanceName].currentlyPlaying += 1;
+    this.setState({instances});
   }
 
   /*
@@ -69,13 +68,9 @@ class SessionList extends React.Component {
    * player disconnects.
    */
   onPlayerRemoved(playerName, instanceName) {
-    for (let i = 0; i < this.state.instances.length; i += 1) {
-      if (this.state.instances[i].name === instanceName) {
-        const { instances } = this.state;
-        instances[i].currentlyPlaying -= 1;
-        this.setState({ instances });
-      }
-    }
+    const { instances } = this.state;
+    instances[instanceName].currentlyPlaying -= 1;
+    this.setState({instances});
   }
 
   /*
@@ -91,10 +86,11 @@ class SessionList extends React.Component {
 
     if (!this.isFiltered(instanceName)) {
       const { instances } = this.state;
-      instances.push(instance);
+      instances[instanceName] = instance;
       this.setState({ instances });
     }
-    this.instances.push(instance);
+
+    this.instances[instanceName] = instance;
   }
 
   /*
@@ -102,22 +98,11 @@ class SessionList extends React.Component {
    */
   onInstanceRemoved(instanceName) {
     if (!this.isFiltered(instanceName)) {
-      for (let i = 0; i < this.state.instances.length; i += 1) {
-        if (this.state.instances[i].name === instanceName) {
-          const { instances } = this.state;
-          instances.splice(i, 1);
-          this.setState({ instances });
-          break;
-        }
-      }
+      const { instances } = this.state;
+      delete instances[instanceName];
+      this.setState({ instances });
     }
-
-    for (let i = 0; i < this.instances.length; i += 1) {
-      if (this.instances[i].name === instanceName) {
-        this.instances.splice(i, 1);
-        break;
-      }
-    }
+    delete this.instances[instanceName];
   }
 
   /**
@@ -136,10 +121,11 @@ class SessionList extends React.Component {
    */
   filterList(filter) {
     this.filter = filter.toLowerCase();
-    const stateInstances = [];
-    for (let i = 0; i < this.instances.length; i += 1) {
-      if (!this.isFiltered(this.instances[i].name)) {
-        stateInstances.push(this.instances[i]);
+    const stateInstances = {};
+    const keys = Object.keys(this.instances)
+    for (let i = 0; i < keys.length; i += 1) {
+      if (!this.isFiltered(keys[i])) {
+        stateInstances[keys[i]] = this.instances[keys[i]];
       }
     }
 
@@ -158,10 +144,11 @@ class SessionList extends React.Component {
             </ListSubheader>
           }
         >
-          {this.state.instances.map(session => (
-            <div key={session.name}>
+          {Object.keys(this.state.instances).map(sessionKey => (
+            <div key={sessionKey}>
               <Session
-                sessionObj={session}
+                sessionObj={this.state.instances[sessionKey]}
+                sessionName={sessionKey}
                 enterSessionWindow={this.props.enterSessionWindow}
                 communication={this.props.communication}
               />


### PR DESCRIPTION
This pull request fixes the filter creating more and more instances with the same name when typing in the filter box. It also changes the instances to objects instead of arrays to be faster and easier to use.

**NOTE THIS WILL BREAK THE SERVICE IF YOU DON'T APPROVE THE array2object PULL REQUEST ON THE SERVICE.**