### PR TITLE
Add wake-lock for screen through NoSleep.js package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "deepstream.io-client-js": "^2.3.0",
     "material-ui": "^1.0.0-beta.38",
     "material-ui-icons": "^1.0.0-beta.36",
+    "nosleep.js": "^0.7.0",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
@@ -13,7 +14,7 @@
   },
   "scripts": {
     "start": "PORT=8080 react-scripts start",
-    "start-local": "PORT=8080 REACT_APP_LOCAL=1 react-scripts start",    
+    "start-local": "PORT=8080 REACT_APP_LOCAL=1 react-scripts start",
     "start-pc": "set PORT=3000 && react-scripts start",
     "start-pc-local": "set PORT=3000 && set REACT_APP_LOCAL=1 && react-scripts start",
     "build": "react-scripts build",

--- a/src/components/GameScreen.js
+++ b/src/components/GameScreen.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import NoSleep from 'nosleep.js';
 import PropTypes from 'prop-types';
 import { Button } from 'material-ui';
 import { withStyles } from 'material-ui/styles';
@@ -69,10 +70,13 @@ class GameScreen extends Component {
 
     this.sensorManager = new SensorManager(props.onSensorChange);
     this.sensorManager.calibrate = this.sensorManager.calibrate.bind(this);
+
+    this.wakeLock = new NoSleep();
   }
 
   componentWillMount() {
     lockScreen();
+    this.wakeLock.enable();
   }
 
   componentDidMount() {
@@ -81,6 +85,7 @@ class GameScreen extends Component {
 
   componentWillUnmount() {
     unlockScreen();
+    this.wakeLock.disable();
 
     this.sensorManager.unbindEventListener();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4712,6 +4712,10 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
+nosleep.js@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/nosleep.js/-/nosleep.js-0.7.0.tgz#cfd919c25523ca0d0f4a69fb3305c083adaee289"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"


### PR DESCRIPTION
Keeps the screen awake in the game by playing a small mp4 video in the background. Using the NoSleep.js package. That package looks lightweight and good. Might remove the soundchannel for android browsers later.