### PR TITLE
Add extra check before leaving page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -32,8 +32,8 @@ class App extends Component {
     }
 
     // Double check when back button is used
-    window.addEventListener("beforeunload", function (e) {
-      let confirmationMessage = 'No leave';
+    window.addEventListener('beforeunload', e => {
+      const confirmationMessage = 'No leave';
       e.returnValue = confirmationMessage;
       return confirmationMessage;
     });

--- a/src/App.js
+++ b/src/App.js
@@ -31,6 +31,13 @@ class App extends Component {
       this.com = new Communication(settings.communication);
     }
 
+    // Double check when back button is used
+    window.addEventListener("beforeunload", function (e) {
+      let confirmationMessage = 'No leave';
+      e.returnValue = confirmationMessage;
+      return confirmationMessage;
+    });
+
     // Bind
     this.enterCharacterSelection = this.enterCharacterSelection.bind(this);
     this.enterGame = this.enterGame.bind(this);


### PR DESCRIPTION
Add an extra popup asking the user for confirmation when leaving or reloading the page. This happens when the back-button is used.

This is the best fix for now, since moving between different screens on back button press requires an entirely different react infrastructure. 